### PR TITLE
T-0002 - Add ruff + mypy to CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Linked Tasks
+- T-____
+
+## What changed
+-
+
+## Validation
+- [ ] CI is green (ruff, mypy, pytest)
+- [ ] Acceptance criteria met
+
+## Risk
+- [ ] No protected paths changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,19 @@
 name: CI
 on: [pull_request]
 jobs:
-  test:
+  lint-type-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install pytest
-      - run: pytest -q
+      - run: pip install -r requirements.txt || true
+      - run: pip install ruff mypy pytest
+      - name: Ruff (lint)
+        run: ruff check .
+      - name: Mypy (types)
+        run: mypy .
+      - name: Pytest
+        run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+select = ["E", "F", "I"]
+exclude = ["venv", ".venv", "build", "dist", ".git", "__pycache__"]
+
+[tool.mypy]
+python_version = "3.11"
+disallow_untyped_defs = true
+warn_unused_ignores = true
+ignore_missing_imports = true
+strict_optional = true

--- a/tasks/T-0002-ruff-mypy.md
+++ b/tasks/T-0002-ruff-mypy.md
@@ -4,7 +4,7 @@ title: Add ruff + mypy to CI
 type: chore
 priority: P2
 depends_on: []
-status: queued
+status: in_review
 owner: unassigned
 estimate: 2h
 acceptance:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,2 +1,2 @@
-def test_smoke():
+def test_smoke() -> None:
     assert True


### PR DESCRIPTION
# Linked Tasks
- T-0002

## What changed
- Add pyproject.toml with ruff/mypy config
- Update CI to run ruff+mypy+pytest
- Add PR template checks

## Validation
- [ ] CI runs and passes
